### PR TITLE
Skip multiple slashes when finding relpath

### DIFF
--- a/lib/libpreopen.c
+++ b/lib/libpreopen.c
@@ -116,7 +116,7 @@ po_find(struct po_map* map, const char *path, cap_rights_t *rights)
 
 	relpath = path + bestlen;
 
-	if (*relpath == '/') {
+	while (*relpath == '/') {
 		relpath++;
 	}
 


### PR DESCRIPTION
For some reason, fontconfig open calls were to '/var/db/fontconfig//foobar', and the resulting openat(x, '/foobar') would be interpreted as an absolute path and denied.