### PR TITLE
Add AT_EACCESS flag to eaccess wrapper

### DIFF
--- a/lib/po_libc_wrappers.c
+++ b/lib/po_libc_wrappers.c
@@ -166,7 +166,7 @@ eaccess(const char *path, int mode)
 {
 	struct po_relpath rel = find_relative(path, NULL);
 
-	return faccessat(rel.dirfd, rel.relative_path, mode, 0);
+	return faccessat(rel.dirfd, rel.relative_path, mode, AT_EACCESS);
 }
 
 /**


### PR DESCRIPTION
This fixes the faccessat call in the eaccess wrapper by adding the AT_EACCESS flag. Without this flag, the function does not check the effective user's permissions, which is the expected behavior of eaccess.